### PR TITLE
Explore unique view counting for blog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,8 @@ Cloudflare KV (VIEW_COUNTS namespace)
 
 ### How It Works
 1. Page loads → JS calls worker with `?increment=true`
-2. Worker hashes `IP:User-Agent` → checks if seen in last 30 days
-3. If new visitor: increment count, store hash with 30-day TTL
+2. Worker hashes `IP:User-Agent` → checks if seen in last 7 days
+3. If new visitor: increment count, store hash with 7-day TTL
 4. Return count → displayed next to read time
 
 ### Deploy Worker Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,43 @@ make serve  # Runs hugo-obsidian then hugo server
 
 ## Deployment
 Push to `hugo` branch → GitHub Actions → Deploys to GitHub Pages
+
+## View Counter (Cloudflare Worker + KV)
+
+### Motivation
+Track unique page views without third-party analytics. Privacy-friendly (no cookies, hashed IPs).
+
+### Architecture
+```
+Browser (raduan.xyz)
+    │ fetch with ?increment=true
+    ▼
+Cloudflare Worker (raduan-view-counter.raduan.workers.dev)
+    │ hash(IP + User-Agent) → check/store in KV
+    ▼
+Cloudflare KV (VIEW_COUNTS namespace)
+```
+
+### Key Files
+- `cloudflare-worker/worker.js` - Worker logic (CORS, hashing, KV ops)
+- `cloudflare-worker/wrangler.toml` - Worker config (KV namespace ID is not secret)
+- `quartz/components/ViewCount.tsx` - React component
+- `quartz/components/scripts/viewcount.inline.ts` - Client-side fetch logic
+- `quartz/components/styles/viewcount.scss` - Styling
+
+### How It Works
+1. Page loads → JS calls worker with `?increment=true`
+2. Worker hashes `IP:User-Agent` → checks if seen in last 30 days
+3. If new visitor: increment count, store hash with 30-day TTL
+4. Return count → displayed next to read time
+
+### Deploy Worker Changes
+```bash
+cd cloudflare-worker
+wrangler deploy
+```
+
+### Security
+- CORS restricts browser requests to allowed origins
+- Visitor hash prevents same person inflating counts
+- KV namespace ID is public (auth required to actually access data)

--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -1,0 +1,125 @@
+# View Counter - Cloudflare Worker Setup
+
+This worker tracks unique page views for your Quartz blog using Cloudflare Workers + KV.
+
+## Prerequisites
+
+1. A [Cloudflare account](https://dash.cloudflare.com/sign-up) (free tier works)
+2. [Node.js](https://nodejs.org/) installed locally
+3. [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
+
+## Setup Steps
+
+### 1. Install Wrangler CLI
+
+```bash
+npm install -g wrangler
+```
+
+### 2. Login to Cloudflare
+
+```bash
+wrangler login
+```
+
+### 3. Create the KV Namespace
+
+```bash
+cd cloudflare-worker
+wrangler kv:namespace create "VIEW_COUNTS"
+```
+
+This will output something like:
+```
+🌀 Creating namespace with title "raduan-view-counter-VIEW_COUNTS"
+✨ Success!
+Add the following to your wrangler.toml:
+[[kv_namespaces]]
+binding = "VIEW_COUNTS"
+id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+### 4. Update wrangler.toml
+
+Copy the `id` from the output and paste it into `wrangler.toml`:
+
+```toml
+[[kv_namespaces]]
+binding = "VIEW_COUNTS"
+id = "YOUR_ACTUAL_KV_NAMESPACE_ID"  # Replace this!
+```
+
+### 5. Deploy the Worker
+
+```bash
+wrangler deploy
+```
+
+This will output your worker URL, something like:
+```
+https://raduan-view-counter.YOUR_SUBDOMAIN.workers.dev
+```
+
+### 6. Update Quartz Layout
+
+Open `quartz.layout.ts` and update the API URL:
+
+```typescript
+const VIEW_COUNT_API_URL = "https://raduan-view-counter.YOUR_SUBDOMAIN.workers.dev"
+```
+
+### 7. (Optional) Custom Domain
+
+If you want a cleaner URL like `views.raduan.xyz`:
+
+1. Go to Cloudflare Dashboard → Workers & Pages → your worker
+2. Click "Settings" → "Triggers"
+3. Add a custom domain
+
+Then update `wrangler.toml`:
+```toml
+routes = [
+  { pattern = "views.raduan.xyz/*", zone_name = "raduan.xyz" }
+]
+```
+
+And update `worker.js` CORS header:
+```javascript
+'Access-Control-Allow-Origin': 'https://raduan.xyz',
+```
+
+## Testing
+
+After deployment, test the API:
+
+```bash
+# Get view count (without incrementing)
+curl "https://your-worker.workers.dev/api/views/blog/my-post"
+
+# Increment and get view count
+curl "https://your-worker.workers.dev/api/views/blog/my-post?increment=true"
+```
+
+## How It Works
+
+1. When a page loads, the inline script calls the worker with `?increment=true`
+2. The worker hashes the visitor's IP + User-Agent
+3. If this hash hasn't visited this page in 30 days, increment the count
+4. Return the current count
+5. The script updates the DOM with the count
+
+## Privacy
+
+- No personal data is stored
+- IP addresses are hashed (one-way, not reversible)
+- Visitor hashes expire after 30 days
+- Only page slugs and counts are stored
+
+## Cost
+
+Cloudflare Workers free tier includes:
+- 100,000 requests/day
+- 1GB KV storage
+- 1,000 KV writes/day
+
+This is more than enough for most blogs.

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -12,12 +12,22 @@
  *   ?increment=true - Increment the count (default: false, just returns count)
  */
 
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': 'https://raduan.xyz',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-  'Content-Type': 'application/json',
-};
+const ALLOWED_ORIGINS = [
+  'https://raduan.xyz',
+  'http://localhost:8080',
+  'http://localhost:3000',
+];
+
+function getCorsHeaders(request) {
+  const origin = request.headers.get('Origin');
+  const allowedOrigin = ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0];
+  return {
+    'Access-Control-Allow-Origin': allowedOrigin,
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Content-Type': 'application/json',
+  };
+}
 
 // TTL for visitor tracking (30 days in seconds)
 const VISITOR_TTL = 30 * 24 * 60 * 60;
@@ -47,17 +57,18 @@ function normalizeSlug(slug) {
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
+    const corsHeaders = getCorsHeaders(request);
 
     // Handle CORS preflight
     if (request.method === 'OPTIONS') {
-      return new Response(null, { headers: CORS_HEADERS });
+      return new Response(null, { headers: corsHeaders });
     }
 
     // Only allow GET requests
     if (request.method !== 'GET') {
       return new Response(JSON.stringify({ error: 'Method not allowed' }), {
         status: 405,
-        headers: CORS_HEADERS,
+        headers: corsHeaders,
       });
     }
 
@@ -66,7 +77,7 @@ export default {
     if (!pathMatch) {
       return new Response(JSON.stringify({ error: 'Not found' }), {
         status: 404,
-        headers: CORS_HEADERS,
+        headers: corsHeaders,
       });
     }
 
@@ -95,28 +106,28 @@ export default {
           ]));
 
           return new Response(JSON.stringify({ slug, count: newCount, unique: true }), {
-            headers: CORS_HEADERS,
+            headers: corsHeaders,
           });
         }
 
         // Returning visitor - just return current count
         const count = parseInt(await env.VIEW_COUNTS.get(countKey) || '0', 10);
         return new Response(JSON.stringify({ slug, count, unique: false }), {
-          headers: CORS_HEADERS,
+          headers: corsHeaders,
         });
       }
 
       // Just return the count without incrementing
       const count = parseInt(await env.VIEW_COUNTS.get(countKey) || '0', 10);
       return new Response(JSON.stringify({ slug, count }), {
-        headers: CORS_HEADERS,
+        headers: corsHeaders,
       });
 
     } catch (error) {
       console.error('Error:', error);
       return new Response(JSON.stringify({ error: 'Internal server error' }), {
         status: 500,
-        headers: CORS_HEADERS,
+        headers: corsHeaders,
       });
     }
   },

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -1,0 +1,123 @@
+/**
+ * View Counter Worker
+ *
+ * Tracks unique page views using Cloudflare Workers + KV
+ *
+ * KV Namespace binding: VIEW_COUNTS
+ *
+ * Endpoints:
+ *   GET /api/views/:slug - Get view count and optionally increment
+ *
+ * Query params:
+ *   ?increment=true - Increment the count (default: false, just returns count)
+ */
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': 'https://raduan.xyz',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json',
+};
+
+// TTL for visitor tracking (30 days in seconds)
+const VISITOR_TTL = 30 * 24 * 60 * 60;
+
+/**
+ * Generate a hash from visitor identifiers
+ */
+async function hashVisitor(request) {
+  const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const userAgent = request.headers.get('User-Agent') || 'unknown';
+  const data = `${ip}:${userAgent}`;
+
+  const encoder = new TextEncoder();
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(data));
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  // Take first 8 chars of hex hash
+  return hashArray.slice(0, 4).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Normalize slug - remove leading/trailing slashes, handle index pages
+ */
+function normalizeSlug(slug) {
+  return slug.replace(/^\/+|\/+$/g, '') || 'index';
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+
+    // Handle CORS preflight
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: CORS_HEADERS });
+    }
+
+    // Only allow GET requests
+    if (request.method !== 'GET') {
+      return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+        status: 405,
+        headers: CORS_HEADERS,
+      });
+    }
+
+    // Parse the path: /api/views/:slug
+    const pathMatch = url.pathname.match(/^\/api\/views\/(.+)$/);
+    if (!pathMatch) {
+      return new Response(JSON.stringify({ error: 'Not found' }), {
+        status: 404,
+        headers: CORS_HEADERS,
+      });
+    }
+
+    const slug = normalizeSlug(decodeURIComponent(pathMatch[1]));
+    const shouldIncrement = url.searchParams.get('increment') === 'true';
+
+    try {
+      const countKey = `count:${slug}`;
+
+      if (shouldIncrement) {
+        const visitorHash = await hashVisitor(request);
+        const seenKey = `seen:${slug}:${visitorHash}`;
+
+        // Check if this visitor has already viewed this page
+        const alreadySeen = await env.VIEW_COUNTS.get(seenKey);
+
+        if (!alreadySeen) {
+          // New unique visitor - increment count
+          const currentCount = parseInt(await env.VIEW_COUNTS.get(countKey) || '0', 10);
+          const newCount = currentCount + 1;
+
+          // Use waitUntil to not block the response
+          ctx.waitUntil(Promise.all([
+            env.VIEW_COUNTS.put(countKey, newCount.toString()),
+            env.VIEW_COUNTS.put(seenKey, '1', { expirationTtl: VISITOR_TTL }),
+          ]));
+
+          return new Response(JSON.stringify({ slug, count: newCount, unique: true }), {
+            headers: CORS_HEADERS,
+          });
+        }
+
+        // Returning visitor - just return current count
+        const count = parseInt(await env.VIEW_COUNTS.get(countKey) || '0', 10);
+        return new Response(JSON.stringify({ slug, count, unique: false }), {
+          headers: CORS_HEADERS,
+        });
+      }
+
+      // Just return the count without incrementing
+      const count = parseInt(await env.VIEW_COUNTS.get(countKey) || '0', 10);
+      return new Response(JSON.stringify({ slug, count }), {
+        headers: CORS_HEADERS,
+      });
+
+    } catch (error) {
+      console.error('Error:', error);
+      return new Response(JSON.stringify({ error: 'Internal server error' }), {
+        status: 500,
+        headers: CORS_HEADERS,
+      });
+    }
+  },
+};

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -29,8 +29,8 @@ function getCorsHeaders(request) {
   };
 }
 
-// TTL for visitor tracking (30 days in seconds)
-const VISITOR_TTL = 30 * 24 * 60 * 60;
+// TTL for visitor tracking (7 days in seconds)
+const VISITOR_TTL = 7 * 24 * 60 * 60;
 
 /**
  * Generate a hash from visitor identifiers

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -1,0 +1,19 @@
+name = "raduan-view-counter"
+main = "worker.js"
+compatibility_date = "2024-01-01"
+
+# KV Namespace binding
+# After creating the KV namespace, add its ID here:
+# Run: wrangler kv:namespace create "VIEW_COUNTS"
+[[kv_namespaces]]
+binding = "VIEW_COUNTS"
+id = "YOUR_KV_NAMESPACE_ID_HERE"
+
+# Optional: Preview namespace for local development
+# Run: wrangler kv:namespace create "VIEW_COUNTS" --preview
+# preview_id = "YOUR_PREVIEW_KV_NAMESPACE_ID_HERE"
+
+# Custom domain (optional - configure after deployment)
+# routes = [
+#   { pattern = "views.raduan.xyz/*", zone_name = "raduan.xyz" }
+# ]

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -7,7 +7,7 @@ compatibility_date = "2024-01-01"
 # Run: wrangler kv:namespace create "VIEW_COUNTS"
 [[kv_namespaces]]
 binding = "VIEW_COUNTS"
-id = "YOUR_KV_NAMESPACE_ID_HERE"
+id = "c0009629e84c43558ec3cf95ff3e86ff"
 
 # Optional: Preview namespace for local development
 # Run: wrangler kv:namespace create "VIEW_COUNTS" --preview

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -89,7 +89,6 @@ const config: QuartzConfig = {
       Plugin.Static(),
       Plugin.Favicon(),
       Plugin.NotFoundPage(),
-      // Comment out CustomOgImages to speed up build time
       Plugin.CustomOgImages(),
     ],
   },

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -28,13 +28,8 @@ export const defaultContentPageLayout: PageLayout = {
       condition: (page) => page.fileData.slug !== "index",
     }),
     Component.ArticleTitle(),
-    Component.Flex({
-      components: [
-        { Component: Component.ContentMeta() },
-        { Component: Component.ViewCount({ apiBaseUrl: VIEW_COUNT_API_URL }) },
-      ],
-      gap: "0",
-    }),
+    Component.ContentMeta(),
+    Component.ViewCount({ apiBaseUrl: VIEW_COUNT_API_URL }),
     Component.TagList(),
   ],
   left: [

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -2,6 +2,10 @@ import { PageLayout, SharedLayout } from "./quartz/cfg"
 import * as Component from "./quartz/components"
 import ImageZoom from "./quartz/components/ImageZoom"
 
+// Configure the view count API URL
+// After deploying your Cloudflare Worker, update this URL
+const VIEW_COUNT_API_URL = "https://raduan-view-counter.YOUR_SUBDOMAIN.workers.dev"
+
 // components shared across all pages
 export const sharedPageComponents: SharedLayout = {
   head: Component.Head(),
@@ -24,7 +28,13 @@ export const defaultContentPageLayout: PageLayout = {
       condition: (page) => page.fileData.slug !== "index",
     }),
     Component.ArticleTitle(),
-    Component.ContentMeta(),
+    Component.Flex({
+      components: [
+        { Component: Component.ContentMeta() },
+        { Component: Component.ViewCount({ apiBaseUrl: VIEW_COUNT_API_URL }) },
+      ],
+      gap: "0.5rem",
+    }),
     Component.TagList(),
   ],
   left: [

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -4,7 +4,7 @@ import ImageZoom from "./quartz/components/ImageZoom"
 
 // Configure the view count API URL
 // After deploying your Cloudflare Worker, update this URL
-const VIEW_COUNT_API_URL = "https://raduan-view-counter.YOUR_SUBDOMAIN.workers.dev"
+const VIEW_COUNT_API_URL = "https://raduan-view-counter.raduan.workers.dev"
 
 // components shared across all pages
 export const sharedPageComponents: SharedLayout = {
@@ -33,7 +33,7 @@ export const defaultContentPageLayout: PageLayout = {
         { Component: Component.ContentMeta() },
         { Component: Component.ViewCount({ apiBaseUrl: VIEW_COUNT_API_URL }) },
       ],
-      gap: "0.5rem",
+      gap: "0",
     }),
     Component.TagList(),
   ],

--- a/quartz/components/ViewCount.tsx
+++ b/quartz/components/ViewCount.tsx
@@ -21,8 +21,8 @@ export default ((opts?: Partial<ViewCountOptions>) => {
       <span class={classNames(displayClass, "view-count")} data-api-url={options.apiBaseUrl}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
+          width="14"
+          height="14"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -34,8 +34,8 @@ export default ((opts?: Partial<ViewCountOptions>) => {
           <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
           <circle cx="12" cy="12" r="3" />
         </svg>
-        <span class="view-count-number" data-view-count>—</span>
-        <span class="view-count-label"> views</span>
+        <span class="view-count-number" data-view-count></span>
+        <span class="view-count-label">views</span>
       </span>
     )
   }

--- a/quartz/components/ViewCount.tsx
+++ b/quartz/components/ViewCount.tsx
@@ -1,0 +1,47 @@
+// @ts-ignore
+import viewCountScript from "./scripts/viewcount.inline"
+import styles from "./styles/viewcount.scss"
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import { classNames } from "../util/lang"
+
+interface ViewCountOptions {
+  /** The base URL of your view count API */
+  apiBaseUrl: string
+}
+
+const defaultOptions: ViewCountOptions = {
+  apiBaseUrl: "https://raduan-view-counter.YOUR_SUBDOMAIN.workers.dev",
+}
+
+export default ((opts?: Partial<ViewCountOptions>) => {
+  const options: ViewCountOptions = { ...defaultOptions, ...opts }
+
+  const ViewCount: QuartzComponent = ({ displayClass }: QuartzComponentProps) => {
+    return (
+      <span class={classNames(displayClass, "view-count")} data-api-url={options.apiBaseUrl}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="view-count-icon"
+        >
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+        <span class="view-count-number" data-view-count>—</span>
+        <span class="view-count-label"> views</span>
+      </span>
+    )
+  }
+
+  ViewCount.afterDOMLoaded = viewCountScript
+  ViewCount.css = styles
+
+  return ViewCount
+}) satisfies QuartzComponentConstructor

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -23,6 +23,7 @@ import Breadcrumbs from "./Breadcrumbs"
 import Comments from "./Comments"
 import Flex from "./Flex"
 import ConditionalRender from "./ConditionalRender"
+import ViewCount from "./ViewCount"
 
 export {
   ArticleTitle,
@@ -50,4 +51,5 @@ export {
   Comments,
   Flex,
   ConditionalRender,
+  ViewCount,
 }

--- a/quartz/components/scripts/viewcount.inline.ts
+++ b/quartz/components/scripts/viewcount.inline.ts
@@ -1,12 +1,16 @@
 document.addEventListener("nav", async () => {
-  const viewCountEl = document.querySelector(".view-count")
+  const viewCountEl = document.querySelector(".view-count") as HTMLElement | null
   if (!viewCountEl) return
 
   const apiBaseUrl = viewCountEl.getAttribute("data-api-url")
   if (!apiBaseUrl) return
 
   const countEl = viewCountEl.querySelector("[data-view-count]")
+  const labelEl = viewCountEl.querySelector(".view-count-label")
   if (!countEl) return
+
+  // Hide initially until we have data
+  viewCountEl.style.display = "none"
 
   // Get the current page slug from the URL
   const slug = window.location.pathname.replace(/^\/+|\/+$/g, "") || "index"
@@ -25,11 +29,19 @@ document.addEventListener("nav", async () => {
     }
 
     const data = await response.json()
-    countEl.textContent = formatCount(data.count)
+
+    // Only show if count > 0
+    if (data.count > 0) {
+      countEl.textContent = formatCount(data.count)
+      // Fix singular/plural
+      if (labelEl) {
+        labelEl.textContent = data.count === 1 ? "view" : "views"
+      }
+      viewCountEl.style.display = "inline-flex"
+    }
   } catch (error) {
     console.error("Failed to fetch view count:", error)
-    // Keep the placeholder or show error state
-    countEl.textContent = "—"
+    // Keep hidden on error
   }
 })
 

--- a/quartz/components/scripts/viewcount.inline.ts
+++ b/quartz/components/scripts/viewcount.inline.ts
@@ -1,0 +1,44 @@
+document.addEventListener("nav", async () => {
+  const viewCountEl = document.querySelector(".view-count")
+  if (!viewCountEl) return
+
+  const apiBaseUrl = viewCountEl.getAttribute("data-api-url")
+  if (!apiBaseUrl) return
+
+  const countEl = viewCountEl.querySelector("[data-view-count]")
+  if (!countEl) return
+
+  // Get the current page slug from the URL
+  const slug = window.location.pathname.replace(/^\/+|\/+$/g, "") || "index"
+
+  try {
+    // Increment and get the view count
+    const response = await fetch(`${apiBaseUrl}/api/views/${encodeURIComponent(slug)}?increment=true`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
+    }
+
+    const data = await response.json()
+    countEl.textContent = formatCount(data.count)
+  } catch (error) {
+    console.error("Failed to fetch view count:", error)
+    // Keep the placeholder or show error state
+    countEl.textContent = "—"
+  }
+})
+
+function formatCount(count: number): string {
+  if (count >= 1000000) {
+    return (count / 1000000).toFixed(1).replace(/\.0$/, "") + "M"
+  }
+  if (count >= 1000) {
+    return (count / 1000).toFixed(1).replace(/\.0$/, "") + "K"
+  }
+  return count.toString()
+}

--- a/quartz/components/styles/viewcount.scss
+++ b/quartz/components/styles/viewcount.scss
@@ -1,0 +1,28 @@
+.view-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--darkgray);
+  font-size: 0.9em;
+
+  // Add separator before view count when it follows content-meta
+  &::before {
+    content: "·";
+    margin-right: 4px;
+    opacity: 0.6;
+  }
+
+  .view-count-icon {
+    width: 14px;
+    height: 14px;
+    opacity: 0.8;
+  }
+
+  .view-count-number {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .view-count-label {
+    opacity: 0.8;
+  }
+}

--- a/quartz/components/styles/viewcount.scss
+++ b/quartz/components/styles/viewcount.scss
@@ -1,21 +1,12 @@
 .view-count {
-  display: inline-flex;
+  display: none; // Hidden by default, shown via JS when count > 0
   align-items: center;
   gap: 4px;
   color: var(--darkgray);
-  font-size: 0.9em;
-
-  // Add separator before view count when it follows content-meta
-  &::before {
-    content: "·";
-    margin-right: 4px;
-    opacity: 0.6;
-  }
+  margin-left: 8px;
 
   .view-count-icon {
-    width: 14px;
-    height: 14px;
-    opacity: 0.8;
+    opacity: 0.7;
   }
 
   .view-count-number {
@@ -23,6 +14,6 @@
   }
 
   .view-count-label {
-    opacity: 0.8;
+    margin-left: -2px;
   }
 }

--- a/quartz/components/styles/viewcount.scss
+++ b/quartz/components/styles/viewcount.scss
@@ -1,12 +1,23 @@
+.content-meta {
+  display: inline !important;
+}
+
 .view-count {
   display: none; // Hidden by default, shown via JS when count > 0
   align-items: center;
   gap: 4px;
   color: var(--darkgray);
-  margin-left: 8px;
+  margin-left: 6px;
+
+  &::before {
+    content: "·";
+    margin-right: 6px;
+    color: var(--darkgray);
+  }
 
   .view-count-icon {
-    opacity: 0.7;
+    opacity: 0.85;
+    margin-right: 2px;
   }
 
   .view-count-number {
@@ -14,6 +25,6 @@
   }
 
   .view-count-label {
-    margin-left: -2px;
+    margin-left: 1px;
   }
 }


### PR DESCRIPTION
- Add ViewCount Quartz component with eye icon and count display
- Add viewcount.inline.ts script to fetch/increment counts on page load
- Add Cloudflare Worker code for tracking unique views via KV storage
- Integrate ViewCount into layout next to ContentMeta
- Include setup documentation for Cloudflare deployment

The worker uses IP+User-Agent hashing for unique visitor tracking with 30-day TTL. View counts are displayed per-page with a dot separator from the content meta.